### PR TITLE
Define open as the default opportunities filter

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,26 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-*
+
+jobs:
+  validation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Validate diff formatting
+        run: git diff --check
+
+      - name: Run focused opportunity status tests
+        run: node --test src/tests/react/utils/opportunityStatusFilter.test.cjs

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "ControleOnline CRM Quasar UI Component",
   "license": "MIT",
   "main": "src/vue/index.js",
-  "scripts": {},
+  "scripts": {
+    "test:opportunity-status-filter": "node --test src/tests/react/utils/opportunityStatusFilter.test.cjs"
+  },
   "repository": {
     "type": "git",
 

--- a/src/react/pages/crm/index.js
+++ b/src/react/pages/crm/index.js
@@ -11,6 +11,10 @@ import { env } from '@env';
 import { useStore } from '@store';
 import { colors } from '@controleonline/../../src/styles/colors';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
+import {
+  getOpportunityStatusFilterKey,
+  resolveDefaultOpportunityStatusFilterKey,
+} from '../../utils/opportunityStatusFilter';
 import useToastMessage from '../../hooks/useToastMessage';
 import styles from './index.styles';
 
@@ -140,22 +144,7 @@ export default function CrmIndex() {
 
 
   const getStatusFilterKey = useCallback(item => {
-    if (!item) {
-      return '';
-    }
-
-    if (item['@id']) {
-      return item['@id'];
-    }
-
-    if (item.id != null) {
-      return `/statuses/${item.id}`;
-    }
-
-    const realStatus = String(item.realStatus || item.status || '')
-      .trim()
-      .toLowerCase();
-    return realStatus ? `realStatus:${realStatus}` : '';
+    return getOpportunityStatusFilterKey(item);
   }, []);
 
   const getStatusFilterLabel = useCallback(item => {
@@ -420,6 +409,20 @@ export default function CrmIndex() {
       setSelectedStatusFilterKey('');
     }
   }, [status, selectedStatusFilterKey, getStatusFilterKey]);
+
+  useEffect(() => {
+    if (selectedStatusFilterKey || status.length === 0) {
+      return;
+    }
+
+    const defaultStatusFilterKey = resolveDefaultOpportunityStatusFilterKey(
+      status,
+    );
+
+    if (defaultStatusFilterKey) {
+      setSelectedStatusFilterKey(defaultStatusFilterKey);
+    }
+  }, [status, selectedStatusFilterKey]);
 
   useEffect(() => {
     const delayDebounceFn = setTimeout(() => {

--- a/src/react/utils/opportunityStatusFilter.js
+++ b/src/react/utils/opportunityStatusFilter.js
@@ -1,0 +1,39 @@
+const normalizeOpportunityStatus = item =>
+  String(item?.realStatus || item?.status || '')
+    .trim()
+    .toLowerCase();
+
+const getOpportunityStatusFilterKey = item => {
+  if (!item) {
+    return '';
+  }
+
+  if (item['@id']) {
+    return item['@id'];
+  }
+
+  if (item.id != null) {
+    return `/statuses/${item.id}`;
+  }
+
+  const normalizedStatus = normalizeOpportunityStatus(item);
+  return normalizedStatus ? `realStatus:${normalizedStatus}` : '';
+};
+
+const resolveDefaultOpportunityStatusFilterKey = statusItems => {
+  if (!Array.isArray(statusItems) || statusItems.length === 0) {
+    return '';
+  }
+
+  const defaultOpenStatus = statusItems.find(
+    item => normalizeOpportunityStatus(item) === 'open',
+  );
+
+  return getOpportunityStatusFilterKey(defaultOpenStatus);
+};
+
+module.exports = {
+  getOpportunityStatusFilterKey,
+  normalizeOpportunityStatus,
+  resolveDefaultOpportunityStatusFilterKey,
+};

--- a/src/tests/react/utils/opportunityStatusFilter.test.cjs
+++ b/src/tests/react/utils/opportunityStatusFilter.test.cjs
@@ -1,0 +1,53 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getOpportunityStatusFilterKey,
+  normalizeOpportunityStatus,
+  resolveDefaultOpportunityStatusFilterKey,
+} = require('../../../react/utils/opportunityStatusFilter');
+
+test('getOpportunityStatusFilterKey prefers @id when available', () => {
+  assert.equal(
+    getOpportunityStatusFilterKey({
+      '@id': '/statuses/9',
+      id: 2,
+      realStatus: 'pending',
+    }),
+    '/statuses/9',
+  );
+});
+
+test('getOpportunityStatusFilterKey falls back to id and real status', () => {
+  assert.equal(getOpportunityStatusFilterKey({ id: 3 }), '/statuses/3');
+  assert.equal(
+    getOpportunityStatusFilterKey({ realStatus: ' Open ' }),
+    'realStatus:open',
+  );
+});
+
+test('normalizeOpportunityStatus trims and lowercases known status values', () => {
+  assert.equal(normalizeOpportunityStatus({ status: ' Pending ' }), 'pending');
+  assert.equal(normalizeOpportunityStatus({ realStatus: 'OPEN' }), 'open');
+});
+
+test('resolveDefaultOpportunityStatusFilterKey selects the open status by default', () => {
+  assert.equal(
+    resolveDefaultOpportunityStatusFilterKey([
+      { id: 1, realStatus: 'pending' },
+      { id: 2, realStatus: 'Open' },
+      { id: 3, realStatus: 'closed' },
+    ]),
+    '/statuses/2',
+  );
+});
+
+test('resolveDefaultOpportunityStatusFilterKey preserves the empty state when open is unavailable', () => {
+  assert.equal(
+    resolveDefaultOpportunityStatusFilterKey([
+      { id: 1, realStatus: 'pending' },
+      { id: 3, realStatus: 'closed' },
+    ]),
+    '',
+  );
+});


### PR DESCRIPTION
## Summary
- set the CRM opportunities list to start with the `open` status selected by default
- keep the manual status chips available so users can still switch to other filters
- preserve the existing fallback when the API does not return an `open` status option
- extract the status filter decision to a focused helper so the default behavior is covered by an automated test

## Validation
- `npm run test:opportunity-status-filter`
- GitHub Actions `Pull Request Checks` workflow on commit `338563ee263a21d9fcbcc9255cd854f832bbe9e7`

## Related
- closes ControleOnline/app-community#70