### PR TITLE
Filter proposal products by model category

### DIFF
--- a/src/react/pages/proposals/CreateProposalsModal.js
+++ b/src/react/pages/proposals/CreateProposalsModal.js
@@ -53,6 +53,15 @@ const formatApiError = error => {
   return error?.message || error?.description || error?.errmsg || 'Nao foi possivel criar a proposta.';
 };
 
+const normalizeCategoryId = value =>
+  normalizeEntityId(
+    value?.category ||
+      value?.parent ||
+      value?.['@id'] ||
+      value?.id ||
+      value,
+  );
+
 const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
   const { showError, showSuccess } = useToastMessage();
   const contractStore = useStore('contract');
@@ -85,6 +94,18 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
   const [productResults, setProductResults] = useState([]);
   const [productSearchLoading, setProductSearchLoading] = useState(false);
   const [selectedProducts, setSelectedProducts] = useState([]);
+  const selectedContractModel = useMemo(
+    () => contractModels.find(model => model['@id'] === selectedModel) || null,
+    [contractModels, selectedModel],
+  );
+  const selectedModelCategoryId = useMemo(
+    () => normalizeCategoryId(selectedContractModel?.category),
+    [selectedContractModel?.category],
+  );
+  const selectedModelCategoryName = useMemo(
+    () => String(selectedContractModel?.category?.name || '').trim(),
+    [selectedContractModel?.category?.name],
+  );
 
   useEffect(() => {
     if (visible) {
@@ -106,11 +127,17 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
         const results = await searchCompanyProducts({
           companyId: currentCompany.id,
           query: productQuery,
-          itemsPerPage: 8,
+          itemsPerPage: selectedModelCategoryId ? 100 : 8,
         });
+        const normalizedResults = Array.isArray(results) ? results : [];
+        const filteredResults = selectedModelCategoryId
+          ? normalizedResults.filter(
+              product => normalizeCategoryId(product?.category) === selectedModelCategoryId,
+            )
+          : normalizedResults;
 
         if (!cancelled) {
-          setProductResults(results);
+          setProductResults(filteredResults);
         }
       } catch (error) {
         if (!cancelled) {
@@ -127,7 +154,19 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
       cancelled = true;
       clearTimeout(timeoutId);
     };
-  }, [visible, currentCompany?.id, productQuery]);
+  }, [visible, currentCompany?.id, productQuery, selectedModelCategoryId]);
+
+  useEffect(() => {
+    if (!selectedModelCategoryId) {
+      return;
+    }
+
+    setSelectedProducts(currentItems =>
+      currentItems.filter(
+        product => normalizeCategoryId(product?.category) === selectedModelCategoryId,
+      ),
+    );
+  }, [selectedModelCategoryId]);
 
   const selectedProductIds = useMemo(
     () => new Set(selectedProducts.map(product => normalizeEntityId(product))),
@@ -140,8 +179,8 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
   );
 
   const selectedModelName = useMemo(
-    () => contractModels.find(model => model['@id'] === selectedModel)?.model || '',
-    [contractModels, selectedModel],
+    () => selectedContractModel?.model || '',
+    [selectedContractModel],
   );
 
   const loadInitialData = async () => {
@@ -340,6 +379,9 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
                   style={[styles.selectOption, selectedModel === model['@id'] && styles.selectOptionActive]}
                   onPress={() => {
                     setSelectedModel(model['@id']);
+                    setProductQuery('');
+                    setProductResults([]);
+                    setSelectedProducts([]);
                     setModelPickerVisible(false);
                   }}>
                   <View style={styles.optionInfo}>
@@ -570,6 +612,11 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
                 <Text style={styles.helperText}>
                   Escolha os produtos que serao encaminhados agora. Voce podera ajustar depois na proposta.
                 </Text>
+                {selectedModelCategoryName ? (
+                  <Text style={styles.helperText}>
+                    Produtos filtrados pela categoria {selectedModelCategoryName}.
+                  </Text>
+                ) : null}
               </View>
               <View style={styles.selectedCountBadge}>
                 <Text style={styles.selectedCountText}>{selectedProducts.length}</Text>
@@ -582,7 +629,11 @@ const CreateProposalsModal = ({ visible, onClose, onSuccess }) => {
                 style={styles.searchInput}
                 value={productQuery}
                 onChangeText={setProductQuery}
-                placeholder="Buscar produto da empresa..."
+                placeholder={
+                  selectedModelCategoryName
+                    ? `Buscar produto em ${selectedModelCategoryName}...`
+                    : 'Buscar produto da empresa...'
+                }
                 placeholderTextColor="#94A3B8"
               />
               {productSearchLoading && <ActivityIndicator size="small" color="#2529a1" />}


### PR DESCRIPTION
## Summary
- filter the proposal product picker by the selected proposal model category
- clear product selections and refresh the search when the proposal model changes
- keep the previous company-wide search behavior when the selected model has no category

## Issue
- relates to ControleOnline/app-community#85

## Validation
- `git diff --check`
- code inspection of `src/react/pages/proposals/CreateProposalsModal.js`

## Note
- this repository does not expose a `dev` branch; the PR targets `master` to keep the diff isolated and reviewable