### PR TITLE
Corrige mensagem vazia ao filtrar oportunidades

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,23 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-43
+
+jobs:
+  crm-empty-state:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run CRM empty-state test
+        run: npm run test:crm-empty-state

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "ControleOnline CRM Quasar UI Component",
   "license": "MIT",
   "main": "src/vue/index.js",
-  "scripts": {},
+  "scripts": {
+    "test:crm-empty-state": "node --test src/tests/react/utils/opportunityEmptyState.test.js"
+  },
   "repository": {
     "type": "git",
 

--- a/src/react/pages/crm/index.js
+++ b/src/react/pages/crm/index.js
@@ -14,6 +14,10 @@ import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import useToastMessage from '../../hooks/useToastMessage';
 import styles from './index.styles';
 
+const {
+  getOpportunityEmptyStateMode,
+} = require('../../utils/opportunityEmptyState');
+
 const FONT_AWESOME_GLYPH_MAP = Icon?.getRawGlyphMap
   ? Icon.getRawGlyphMap()
   : null;
@@ -552,9 +556,10 @@ export default function CrmIndex() {
     searchQuery,
   ]);
 
-  const hasActiveOpportunityFilters = Boolean(
-    normalizeSearchValue(searchQuery) || selectedStatusFilterKey,
-  );
+  const opportunityEmptyStateMode = getOpportunityEmptyStateMode({
+    searchQuery,
+    selectedStatusFilterKey,
+  });
 
   const showStatusFilterSkeleton =
     isStatusLoading || isStatusFilterBootstrapping;
@@ -2070,12 +2075,12 @@ export default function CrmIndex() {
                 <>
                   <Icon name="line-chart" size={64} color="#bdc3c7" />
                   <Text style={styles.emptyTitle}>
-                    {hasActiveOpportunityFilters
+                    {opportunityEmptyStateMode === 'filtered'
                       ? global.t?.t('people', 'state', 'noOpportunityFound')
                       : global.t?.t('people', 'state', 'noOpportunity')}
                   </Text>
                   <Text style={styles.emptySubtitle}>
-                    {hasActiveOpportunityFilters
+                    {opportunityEmptyStateMode === 'filtered'
                       ? global.t?.t('people', 'state', 'tryOtherTerms')
                       : global.t?.t('people', 'state', 'addFirstOpportunity')}
                   </Text>

--- a/src/react/pages/crm/index.js
+++ b/src/react/pages/crm/index.js
@@ -552,6 +552,10 @@ export default function CrmIndex() {
     searchQuery,
   ]);
 
+  const hasActiveOpportunityFilters = Boolean(
+    normalizeSearchValue(searchQuery) || selectedStatusFilterKey,
+  );
+
   const showStatusFilterSkeleton =
     isStatusLoading || isStatusFilterBootstrapping;
 
@@ -2066,12 +2070,12 @@ export default function CrmIndex() {
                 <>
                   <Icon name="line-chart" size={64} color="#bdc3c7" />
                   <Text style={styles.emptyTitle}>
-                    {searchQuery
+                    {hasActiveOpportunityFilters
                       ? global.t?.t('people', 'state', 'noOpportunityFound')
                       : global.t?.t('people', 'state', 'noOpportunity')}
                   </Text>
                   <Text style={styles.emptySubtitle}>
-                    {searchQuery
+                    {hasActiveOpportunityFilters
                       ? global.t?.t('people', 'state', 'tryOtherTerms')
                       : global.t?.t('people', 'state', 'addFirstOpportunity')}
                   </Text>

--- a/src/react/utils/opportunityEmptyState.js
+++ b/src/react/utils/opportunityEmptyState.js
@@ -1,0 +1,20 @@
+const normalizeSearchValue = value =>
+  String(value || '')
+    .trim()
+    .toLowerCase();
+
+const hasActiveOpportunityFilters = ({
+  searchQuery = '',
+  selectedStatusFilterKey = '',
+} = {}) =>
+  Boolean(
+    normalizeSearchValue(searchQuery) || String(selectedStatusFilterKey || '').trim(),
+  );
+
+const getOpportunityEmptyStateMode = filters =>
+  hasActiveOpportunityFilters(filters) ? 'filtered' : 'empty';
+
+module.exports = {
+  getOpportunityEmptyStateMode,
+  hasActiveOpportunityFilters,
+};

--- a/src/tests/react/utils/opportunityEmptyState.test.js
+++ b/src/tests/react/utils/opportunityEmptyState.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getOpportunityEmptyStateMode,
+  hasActiveOpportunityFilters,
+} = require('../../../react/utils/opportunityEmptyState');
+
+test('returns empty mode when there is no search term or status filter', () => {
+  assert.equal(getOpportunityEmptyStateMode({}), 'empty');
+  assert.equal(
+    hasActiveOpportunityFilters({ searchQuery: '   ', selectedStatusFilterKey: '' }),
+    false,
+  );
+});
+
+test('returns filtered mode when there is a search term', () => {
+  assert.equal(
+    getOpportunityEmptyStateMode({ searchQuery: '  acme  ' }),
+    'filtered',
+  );
+});
+
+test('returns filtered mode when there is a selected status filter', () => {
+  assert.equal(
+    getOpportunityEmptyStateMode({ selectedStatusFilterKey: '/statuses/3' }),
+    'filtered',
+  );
+});
+
+test('treats either filter source as enough to show the filtered empty state', () => {
+  assert.equal(
+    hasActiveOpportunityFilters({
+      searchQuery: 'cliente',
+      selectedStatusFilterKey: 'realStatus:closed',
+    }),
+    true,
+  );
+});


### PR DESCRIPTION
## Resumo
- ajusta o estado vazio da listagem de oportunidades para tratar filtro de status como filtro ativo
- extrai a decisão do estado vazio para o helper `src/react/utils/opportunityEmptyState.js`
- preserva a mensagem de lista realmente vazia quando não há busca nem filtro ativo
- adiciona um workflow mínimo para publicar a validação automatizada no próprio PR

## Issue
- atende `ControleOnline/app-community#43`

## Validação
- `npm run test:crm-empty-state`
- workflow `Pull Request Checks` verde no commit `a756a72`