### PR TITLE
Ordena oportunidades pela data de retorno mais antiga

### DIFF
--- a/src/react/pages/crm/index.js
+++ b/src/react/pages/crm/index.js
@@ -382,29 +382,53 @@ export default function CrmIndex() {
 
   const visibleOpportunities = React.useMemo(() => {
     const normalizedQuery = normalizeSearchValue(searchQuery);
-    if (!normalizedQuery) {
-      return allOpportunities;
-    }
+    const filteredOpportunities = !normalizedQuery
+      ? allOpportunities
+      : allOpportunities.filter(opportunity => {
+        const clientIdentity = getOpportunityClientIdentity(opportunity);
+        const searchableFields = [
+          clientIdentity.name,
+          clientIdentity.alias,
+          `${clientIdentity.name} ${clientIdentity.alias}`.trim(),
+        ];
 
-    return allOpportunities.filter(opportunity => {
-      const clientIdentity = getOpportunityClientIdentity(opportunity);
-      const searchableFields = [
-        clientIdentity.name,
-        clientIdentity.alias,
-        `${clientIdentity.name} ${clientIdentity.alias}`.trim(),
-      ];
+        const availableFields = searchableFields.filter(field =>
+          normalizeSearchValue(field).length > 0,
+        );
 
-      const availableFields = searchableFields.filter(field =>
-        normalizeSearchValue(field).length > 0,
-      );
+        if (availableFields.length === 0) {
+          return true;
+        }
 
-      if (availableFields.length === 0) {
-        return true;
+        return availableFields.some(field =>
+          normalizeSearchValue(field).includes(normalizedQuery),
+        );
+      });
+
+    return [...filteredOpportunities].sort((leftOpportunity, rightOpportunity) => {
+      const leftDateValue =
+        leftOpportunity?.dueDate || leftOpportunity?.alterDate || null;
+      const rightDateValue =
+        rightOpportunity?.dueDate || rightOpportunity?.alterDate || null;
+      const leftTimestamp = leftDateValue
+        ? new Date(leftDateValue).getTime()
+        : Number.POSITIVE_INFINITY;
+      const rightTimestamp = rightDateValue
+        ? new Date(rightDateValue).getTime()
+        : Number.POSITIVE_INFINITY;
+
+      const normalizedLeftTimestamp = Number.isNaN(leftTimestamp)
+        ? Number.POSITIVE_INFINITY
+        : leftTimestamp;
+      const normalizedRightTimestamp = Number.isNaN(rightTimestamp)
+        ? Number.POSITIVE_INFINITY
+        : rightTimestamp;
+
+      if (normalizedLeftTimestamp !== normalizedRightTimestamp) {
+        return normalizedLeftTimestamp - normalizedRightTimestamp;
       }
 
-      return availableFields.some(field =>
-        normalizeSearchValue(field).includes(normalizedQuery),
-      );
+      return (leftOpportunity?.id || 0) - (rightOpportunity?.id || 0);
     });
   }, [
     allOpportunities,


### PR DESCRIPTION
## Resumo
- ordena a listagem de oportunidades pela data de retorno da mais antiga para a mais nova
- aplica a ordenação depois do filtro de busca para manter o mesmo comportamento de pesquisa
- envia itens sem data valida para o final da lista e usa o id como desempate estavel

## Issue
- atende `ControleOnline/app-community#69`

## Validacao
- revisao do diff no modulo `ui-crm`
- este modulo nao expoe scripts de lint/teste no `package.json`, entao nao houve execucao automatizada adicional