### PR TITLE
fix: issue #2 open customer details with seller context from crm

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,23 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-2
+
+jobs:
+  crm-client-navigation:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Run CRM client navigation test
+        run: npm run test:crm-client-navigation

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "ControleOnline CRM Quasar UI Component",
   "license": "MIT",
   "main": "src/vue/index.js",
-  "scripts": {},
+  "scripts": {
+    "test:crm-client-navigation": "node --test src/tests/react/utils/clientDetailsNavigation.test.js"
+  },
   "repository": {
     "type": "git",
 

--- a/src/react/pages/crm/index.js
+++ b/src/react/pages/crm/index.js
@@ -730,13 +730,35 @@ export default function CrmIndex() {
           name: getProviderName(opportunity?.client) || global.t?.t('people', 'label', 'client'),
         };
 
-      navigation.navigate('ClientDetails', { client: selectedClient });
+      const clientId = extractId(reference);
+      const isLegalEntity =
+        String(
+          selectedClient?.peopleType ||
+            matchedPerson?.peopleType ||
+            opportunity?.client?.peopleType ||
+            '',
+        ).trim().toUpperCase() === 'J';
+
+      if (!clientId) {
+        showError?.(
+          global.t?.t('people', 'toast', 'providerNotIdentified'),
+        );
+        return;
+      }
+
+      peopleActions?.setItem?.(selectedClient);
+      navigation.navigate('ClientDetails', {
+        clientId,
+        contextKey: 'client',
+        initialTab: isLegalEntity ? 'sellers' : 'general',
+      });
     },
     [
       getProviderName,
       getPersonByReference,
       navigation,
       normalizePeopleReference,
+      peopleActions,
       showError,
     ],
   );

--- a/src/react/pages/crm/index.js
+++ b/src/react/pages/crm/index.js
@@ -12,6 +12,9 @@ import { useStore } from '@store';
 import { colors } from '@controleonline/../../src/styles/colors';
 import { useFocusEffect, useNavigation } from '@react-navigation/native';
 import useToastMessage from '../../hooks/useToastMessage';
+const {
+  resolveClientDetailsNavigation,
+} = require('../../utils/clientDetailsNavigation');
 import styles from './index.styles';
 
 const FONT_AWESOME_GLYPH_MAP = Icon?.getRawGlyphMap
@@ -711,47 +714,25 @@ export default function CrmIndex() {
   const handleEditProvider = useCallback(
     opportunity => {
       const reference = normalizePeopleReference(opportunity?.client);
-      if (!reference) {
-        showError?.(
-          global.t?.t('people', 'toast', 'providerNotIdentified'),
-        );
-        return;
-      }
-
       const matchedPerson = getPersonByReference(opportunity?.client);
-      const selectedClient =
-        matchedPerson ||
-        (typeof opportunity?.client === 'object' && opportunity?.client
-          ? opportunity.client
-          : null) ||
-        {
-          id: extractId(reference),
-          '@id': reference,
-          name: getProviderName(opportunity?.client) || global.t?.t('people', 'label', 'client'),
-        };
+      const navigationContext = resolveClientDetailsNavigation({
+        reference,
+        matchedPerson,
+        opportunityClient: opportunity?.client,
+        fallbackName:
+          getProviderName(opportunity?.client) ||
+          global.t?.t('people', 'label', 'client'),
+      });
 
-      const clientId = extractId(reference);
-      const isLegalEntity =
-        String(
-          selectedClient?.peopleType ||
-            matchedPerson?.peopleType ||
-            opportunity?.client?.peopleType ||
-            '',
-        ).trim().toUpperCase() === 'J';
-
-      if (!clientId) {
+      if (!navigationContext) {
         showError?.(
           global.t?.t('people', 'toast', 'providerNotIdentified'),
         );
         return;
       }
 
-      peopleActions?.setItem?.(selectedClient);
-      navigation.navigate('ClientDetails', {
-        clientId,
-        contextKey: 'client',
-        initialTab: isLegalEntity ? 'sellers' : 'general',
-      });
+      peopleActions?.setItem?.(navigationContext.selectedClient);
+      navigation.navigate('ClientDetails', navigationContext.params);
     },
     [
       getProviderName,

--- a/src/react/utils/clientDetailsNavigation.js
+++ b/src/react/utils/clientDetailsNavigation.js
@@ -1,0 +1,50 @@
+const extractId = value => String(value || '').replace(/\D/g, '');
+
+const resolveClientDetailsNavigation = ({
+  reference,
+  matchedPerson,
+  opportunityClient,
+  fallbackName,
+} = {}) => {
+  const normalizedReference = String(reference || '').trim();
+  if (!normalizedReference) {
+    return null;
+  }
+
+  const selectedClient =
+    matchedPerson ||
+    (typeof opportunityClient === 'object' && opportunityClient
+      ? opportunityClient
+      : null) || {
+      id: extractId(normalizedReference),
+      '@id': normalizedReference,
+      name: fallbackName,
+    };
+
+  const clientId = extractId(normalizedReference);
+  if (!clientId) {
+    return null;
+  }
+
+  const peopleType = String(
+    selectedClient?.peopleType ||
+      matchedPerson?.peopleType ||
+      opportunityClient?.peopleType ||
+      '',
+  )
+    .trim()
+    .toUpperCase();
+
+  return {
+    selectedClient,
+    params: {
+      clientId,
+      contextKey: 'client',
+      initialTab: peopleType === 'J' ? 'sellers' : 'general',
+    },
+  };
+};
+
+module.exports = {
+  resolveClientDetailsNavigation,
+};

--- a/src/tests/react/utils/clientDetailsNavigation.test.js
+++ b/src/tests/react/utils/clientDetailsNavigation.test.js
@@ -1,0 +1,80 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  resolveClientDetailsNavigation,
+} = require('../../../react/utils/clientDetailsNavigation');
+
+test('returns null when the client reference is missing', () => {
+  assert.equal(resolveClientDetailsNavigation({ reference: '' }), null);
+});
+
+test('opens legal entities in the sellers tab with client context', () => {
+  const result = resolveClientDetailsNavigation({
+    reference: '/people/42',
+    opportunityClient: {
+      '@id': '/people/42',
+      peopleType: 'J',
+      name: 'ACME Ltda',
+    },
+    fallbackName: 'Cliente',
+  });
+
+  assert.deepEqual(result, {
+    selectedClient: {
+      '@id': '/people/42',
+      peopleType: 'J',
+      name: 'ACME Ltda',
+    },
+    params: {
+      clientId: '42',
+      contextKey: 'client',
+      initialTab: 'sellers',
+    },
+  });
+});
+
+test('opens non-legal-entity clients in the general tab', () => {
+  const result = resolveClientDetailsNavigation({
+    reference: '/people/13',
+    opportunityClient: {
+      '@id': '/people/13',
+      peopleType: 'F',
+      name: 'Maria',
+    },
+    fallbackName: 'Cliente',
+  });
+
+  assert.equal(result.params.initialTab, 'general');
+  assert.equal(result.params.clientId, '13');
+});
+
+test('prefers the matched person and preserves its id for store context', () => {
+  const matchedPerson = {
+    '@id': '/people/88',
+    id: 88,
+    peopleType: 'J',
+    name: 'Cliente do cache',
+  };
+
+  const result = resolveClientDetailsNavigation({
+    reference: '/people/88',
+    matchedPerson,
+    opportunityClient: '/people/88',
+    fallbackName: 'Cliente',
+  });
+
+  assert.equal(result.selectedClient, matchedPerson);
+  assert.equal(result.params.initialTab, 'sellers');
+});
+
+test('returns null when the reference has no numeric id to navigate with safety', () => {
+  assert.equal(
+    resolveClientDetailsNavigation({
+      reference: '/people/abc',
+      opportunityClient: { '@id': '/people/abc', peopleType: 'J' },
+      fallbackName: 'Cliente',
+    }),
+    null,
+  );
+});


### PR DESCRIPTION
## Issue
- atende `ControleOnline/ui-crm#2`

## O que mudou
- extrai a decisão de navegação do CRM para um helper puro, evitando abrir `ClientDetails` sem `clientId` válido
- envia o contexto `client` para o detalhe carregar a tela correta e abre clientes PJ diretamente na aba de vendedores
- preserva o cliente selecionado no store para o detalhe reaproveitar o contexto já resolvido
- bloqueia a navegação quando a referência do cliente não é segura para evitar abrir uma tela inconsistente

## Validação
- `npm run test:crm-client-navigation`
- workflow `Pull Request Checks` no branch `task-2`

## Coverage Evidence
- vínculo automático quando o cliente ainda não tem vendedor: já existe no backend compartilhado em `ControleOnline/api-platform-people`, onde `SalesmanService::discoverSalesmanForClient` cria o link `sellers-client` e `getSalesmanFromCompany` usa o vendedor logado quando ele já pertence à empresa, ou então delega para `SalesmanDistributionService` escolher um vendedor válido por estratégia de distribuição
- exibição do vendedor para o usuário de CRM: o handoff agora chega em `ClientDetails` com `clientId`, `contextKey=client` e `initialTab=sellers`, permitindo abrir direto a aba correta no detalhe do cliente
- restrições fora do `MANAGER`: o detalhe de cliente em `ControleOnline/ui-customers` abre a aba `sellers` apenas para cliente PJ e o `SalesmanTab` lista os vendedores vinculados sem renderizar comissão nem comissão mínima; para o público de CRM, a evidência publicada cobre justamente essa visualização restrita
- fronteira entre apps: `app-community/MODOS_OPERACAO.md` define `CRM` como visão comercial e `MANAGER` como visão administrativa, e o `AGENTS.md` de `ui-crm` reforça que este módulo não deve assumir responsabilidades administrativas do `MANAGER`

## Observações
- nesta trilha, o `ui-crm` é o último elo do fluxo de CRM: ele precisava abrir o detalhe do cliente com o contexto correto para que a trilha de vendedores já existente no ecossistema ficasse acessível e verificável
- o repositório não expõe `dev`, então o PR segue para `master`