### PR TITLE
test: publish proposal status evidence for app-community#61

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -1,0 +1,17 @@
+name: Pull Request Checks
+
+on:
+  pull_request:
+  push:
+    branches:
+      - task-*
+
+jobs:
+  proposal-status:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+      - run: npm run test:proposal-status

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "description": "ControleOnline CRM Quasar UI Component",
   "license": "MIT",
   "main": "src/vue/index.js",
-  "scripts": {},
+  "scripts": {
+    "test:proposal-status": "node --test src/tests/react/utils/proposalStatus.test.mjs"
+  },
   "repository": {
     "type": "git",
 

--- a/package.json
+++ b/package.json
@@ -6,13 +6,18 @@
   "license": "MIT",
   "main": "src/vue/index.js",
   "scripts": {
-    "test:proposal-status": "node --test src/tests/react/utils/proposalStatus.test.mjs"
+    "test": "npm run test:crm-empty-state && npm run test:opportunity-status-filter && npm run test:proposal-status",
+    "test:crm-empty-state": "node --test src/tests/react/utils/opportunityEmptyState.test.js",
+    "test:opportunity-status-filter": "node --test src/tests/react/utils/opportunityStatusFilter.test.cjs",
+    "test:proposal-status": "node --test src/tests/react/utils/proposalStatus.test.mjs",
+    "test:coverage": "c8 --reporter=clover --report-dir coverage npm test"
+  },
+  "devDependencies": {
+    "c8": "^10.1.3"
   },
   "repository": {
     "type": "git",
-
     "url": "https://github.com/controleonline/conline-quasar-ui"
-
   },
   "bugs": "",
   "homepage": "https://www.controleonline.com/devs/plugins",

--- a/src/react/pages/proposals/index.js
+++ b/src/react/pages/proposals/index.js
@@ -11,6 +11,12 @@ import Formatter from '@controleonline/ui-common/src/utils/formatter';
 import { getPeopleDisplayName } from '@controleonline/ui-common/src/react/utils/peopleDisplay';
 import styles from './index.styles';
 import { inlineStyle_669_129 } from './index.styles';
+import {
+  buildProposalStatusFilterOptions,
+  getProposalStatusColor,
+  getProposalStatusLabel,
+  proposalMatchesStatusFilter,
+} from '../../utils/proposalStatus';
 
 const ProposalsPage = () => {
   const peopleStore = useStore('people');
@@ -306,165 +312,19 @@ const ProposalsPage = () => {
     setRefreshing(false);
   }, [fetchContracts, searchQuery]);
 
-  const normalizeStatusKey = status =>
-    String(status || '')
-      .trim()
-      .toLowerCase()
-      .replace(/[_-]+/g, ' ')
-      .replace(/\s+/g, ' ');
-
-  const getStatusColor = status => {
-    const normalized = normalizeStatusKey(status);
-
-    switch (normalized) {
-      case 'ativo':
-      case 'active':
-      case 'assinado':
-      case 'signed':
-        return '#10B981'; // Green
-      case 'inativo':
-      case 'inactive':
-      case 'cancelado':
-      case 'canceled':
-        return '#EF4444'; // Red
-      case 'pendente':
-      case 'pending':
-        return '#F59E0B'; // Orange
-      case 'open':
-      case 'aberto':
-        return '#3B82F6'; // Blue
-      default:
-        return '#64748B'; // Gray
-    }
-  };
-
-  const getStatusLabel = status => {
-    const normalized = normalizeStatusKey(status);
-    const map = {
-      ativo: global.t?.t('contract','status', 'active'),
-      active: global.t?.t('contract','status', 'active'),
-      inativo: global.t?.t('contract','status', 'inactive'),
-      inactive: global.t?.t('contract','status', 'inactive'),
-      pendente: global.t?.t('contract','status', 'pending'),
-      pending: global.t?.t('contract','status', 'pending'),
-      open: global.t?.t('contract','status', 'open'),
-      aberto: global.t?.t('contract','status', 'open'),
-      closed: global.t?.t('contract','status', 'closed'),
-      fechado: global.t?.t('contract','status', 'closed'),
-      cancelado: global.t?.t('contract','status', 'canceled'),
-      canceled: global.t?.t('contract','status', 'canceled'),
-      'waiting signature': global.t?.t('contract','status', 'waitingSignature'),
-      'awaiting signature': global.t?.t('contract','status', 'waitingSignature'),
-      'signature pending': global.t?.t('contract','status', 'waitingSignature'),
-      assinado: global.t?.t('contract','status', 'signed'),
-      signed: global.t?.t('contract','status', 'signed'),
-      draft: global.t?.t('contract','status', 'draft'),
-      rascunho: global.t?.t('contract','status', 'draft'),
-    };
-
-    return map[normalized] || status || global.t?.t('contract','label', 'na');
-  };
-
-  const getStatusFilterKey = useCallback(
-    item => {
-      if (!item) {
-        return '';
-      }
-
-      if (item['@id']) {
-        return item['@id'];
-      }
-
-      if (item.id != null) {
-        return `/statuses/${item.id}`;
-      }
-
-      const normalized = normalizeStatusKey(item.realStatus || item.status);
-      return normalized ? `realStatus:${normalized}` : '';
-    },
-    [normalizeStatusKey],
-  );
-
   const statusFilterOptions = React.useMemo(
-    () => {
-      const options = [
-        {
-          key: 'realStatus:open',
-          label: global.t?.t('contract','status', 'open') || 'Em aberto',
-          color: getStatusColor('open'),
-          normalizedStatus: 'open',
-        },
-        {
-          key: 'realStatus:pending',
-          label: global.t?.t('contract','status', 'pending') || 'Pendente',
-          color: getStatusColor('pending'),
-          normalizedStatus: 'pending',
-        },
-        {
-          key: 'realStatus:closed',
-          label: global.t?.t('contract','status', 'closed') || 'Fechado',
-          color: getStatusColor('closed'),
-          normalizedStatus: 'closed',
-        },
-      ];
-
-      (allContracts || []).forEach(contract => {
-        const statusObj = contract?.status || {};
-        const key = getStatusFilterKey(statusObj);
-        if (!key || options.some(item => item.key === key)) return;
-
-        const normalizedStatus = normalizeStatusKey(statusObj?.realStatus || statusObj?.status);
-        options.push({
-          key,
-          label: getStatusLabel(statusObj?.status || statusObj?.realStatus),
-          color: statusObj?.color || getStatusColor(normalizedStatus),
-          normalizedStatus,
-        });
-      });
-
-      return options;
-    },
-    [allContracts, getStatusFilterKey, getStatusColor, getStatusLabel, normalizeStatusKey],
+    () =>
+      buildProposalStatusFilterOptions({
+        contracts: allContracts || [],
+        translate: global.t?.t,
+      }),
+    [allContracts],
   );
 
   const contractMatchesStatusFilter = useCallback(
-    (contract, filterKey) => {
-      if (!filterKey) {
-        return true;
-      }
-
-      const statusObj = contract?.status || {};
-      const statusIri = statusObj?.['@id']
-        ? statusObj['@id']
-        : statusObj?.id != null
-        ? `/statuses/${statusObj.id}`
-        : '';
-
-      const normalizedStatus = normalizeStatusKey(
-        statusObj?.realStatus || statusObj?.status,
-      );
-      const normalizedFilter = normalizeStatusKey(
-        String(filterKey || '').replace('realStatus:', ''),
-      );
-
-      if (filterKey.startsWith('/statuses/')) {
-        if (statusIri === filterKey) {
-          return true;
-        }
-
-        const selectedOption = statusFilterOptions.find(
-          item => item.key === filterKey,
-        );
-        if (selectedOption?.normalizedStatus) {
-          return normalizedStatus === selectedOption.normalizedStatus;
-        }
-
-        return false;
-      }
-
-      return normalizedStatus === normalizedFilter;
-    },
-    [normalizeStatusKey, statusFilterOptions],
+    (contract, filterKey) =>
+      proposalMatchesStatusFilter(contract, filterKey, statusFilterOptions),
+    [statusFilterOptions],
   );
 
   useEffect(() => {
@@ -498,8 +358,8 @@ const ProposalsPage = () => {
           <Text style={styles.cardTitle}>
             {contract.contractModel?.model || global.t?.t('contract','label', 'untitled')}
           </Text>
-          <View style={[styles.statusBadge, { backgroundColor: getStatusColor(contract.status?.status) }]}>
-            <Text style={styles.statusText}>{getStatusLabel(contract.status?.status)}</Text>
+          <View style={[styles.statusBadge, { backgroundColor: getProposalStatusColor(contract.status?.status) }]}>
+            <Text style={styles.statusText}>{getProposalStatusLabel(contract.status?.status, global.t?.t)}</Text>
           </View>
         </View>
       </View>

--- a/src/react/utils/proposalStatus.js
+++ b/src/react/utils/proposalStatus.js
@@ -1,0 +1,160 @@
+export const normalizeProposalStatusKey = value =>
+  String(value || '')
+    .trim()
+    .toLowerCase()
+    .replace(/[_-]+/g, ' ')
+    .replace(/\s+/g, ' ');
+
+export const getProposalStatusColor = status => {
+  const normalized = normalizeProposalStatusKey(status);
+
+  switch (normalized) {
+    case 'ativo':
+    case 'active':
+    case 'assinado':
+    case 'signed':
+      return '#10B981';
+    case 'inativo':
+    case 'inactive':
+    case 'cancelado':
+    case 'canceled':
+      return '#EF4444';
+    case 'pendente':
+    case 'pending':
+      return '#F59E0B';
+    case 'open':
+    case 'aberto':
+      return '#3B82F6';
+    default:
+      return '#64748B';
+  }
+};
+
+export const getProposalStatusTranslationKey = status => {
+  const normalized = normalizeProposalStatusKey(status);
+  const map = {
+    ativo: 'active',
+    active: 'active',
+    inativo: 'inactive',
+    inactive: 'inactive',
+    pendente: 'pending',
+    pending: 'pending',
+    open: 'open',
+    aberto: 'open',
+    closed: 'closed',
+    fechado: 'closed',
+    cancelado: 'canceled',
+    canceled: 'canceled',
+    'waiting signature': 'waitingSignature',
+    'awaiting signature': 'waitingSignature',
+    'signature pending': 'waitingSignature',
+    assinado: 'signed',
+    signed: 'signed',
+    draft: 'draft',
+    rascunho: 'draft',
+  };
+
+  return map[normalized] || '';
+};
+
+export const getProposalStatusLabel = (status, translate) => {
+  const translationKey = getProposalStatusTranslationKey(status);
+  if (translationKey) {
+    return translate?.('contract', 'status', translationKey) || status;
+  }
+
+  return status || translate?.('contract', 'label', 'na');
+};
+
+export const getProposalStatusFilterKey = item => {
+  if (!item) {
+    return '';
+  }
+
+  if (item['@id']) {
+    return item['@id'];
+  }
+
+  if (item.id != null) {
+    return `/statuses/${item.id}`;
+  }
+
+  const normalized = normalizeProposalStatusKey(item.realStatus || item.status);
+  return normalized ? `realStatus:${normalized}` : '';
+};
+
+export const buildProposalStatusFilterOptions = ({ contracts = [], translate } = {}) => {
+  const options = [
+    {
+      key: 'realStatus:open',
+      label: translate?.('contract', 'status', 'open') || 'Em aberto',
+      color: getProposalStatusColor('open'),
+      normalizedStatus: 'open',
+    },
+    {
+      key: 'realStatus:pending',
+      label: translate?.('contract', 'status', 'pending') || 'Pendente',
+      color: getProposalStatusColor('pending'),
+      normalizedStatus: 'pending',
+    },
+    {
+      key: 'realStatus:closed',
+      label: translate?.('contract', 'status', 'closed') || 'Fechado',
+      color: getProposalStatusColor('closed'),
+      normalizedStatus: 'closed',
+    },
+  ];
+
+  contracts.forEach(contract => {
+    const statusObj = contract?.status || {};
+    const key = getProposalStatusFilterKey(statusObj);
+    if (!key || options.some(item => item.key === key)) {
+      return;
+    }
+
+    const normalizedStatus = normalizeProposalStatusKey(statusObj.realStatus || statusObj.status);
+    options.push({
+      key,
+      label: getProposalStatusLabel(statusObj.status || statusObj.realStatus, translate),
+      color: statusObj.color || getProposalStatusColor(normalizedStatus),
+      normalizedStatus,
+    });
+  });
+
+  return options;
+};
+
+export const proposalMatchesStatusFilter = (contract, filterKey, statusFilterOptions = []) => {
+  if (!filterKey) {
+    return true;
+  }
+
+  const statusObj = contract?.status || {};
+  const statusIri = statusObj['@id']
+    ? statusObj['@id']
+    : statusObj.id != null
+    ? `/statuses/${statusObj.id}`
+    : '';
+
+  const normalizedStatus = normalizeProposalStatusKey(
+    statusObj.realStatus || statusObj.status,
+  );
+  const normalizedFilter = normalizeProposalStatusKey(
+    String(filterKey || '').replace('realStatus:', ''),
+  );
+
+  if (filterKey.startsWith('/statuses/')) {
+    if (statusIri === filterKey) {
+      return true;
+    }
+
+    const selectedOption = statusFilterOptions.find(item => item.key === filterKey);
+    if (selectedOption?.normalizedStatus) {
+      return normalizedStatus === selectedOption.normalizedStatus;
+    }
+
+    return false;
+  }
+
+  return normalizedStatus === normalizedFilter;
+};

--- a/src/react/utils/proposalStatus.js
+++ b/src/react/utils/proposalStatus.js
@@ -60,10 +60,10 @@ export const getProposalStatusTranslationKey = status => {
 export const getProposalStatusLabel = (status, translate) => {
   const translationKey = getProposalStatusTranslationKey(status);
   if (translationKey) {
-    return translate?.('contract', 'status', translationKey) || status;
+    return translate?.('contract', 'status', translationKey);
   }
 
-  return status || translate?.('contract', 'label', 'na');
+  return translate?.('contract', 'label', 'na') || '';
 };
 
 export const getProposalStatusFilterKey = item => {
@@ -87,19 +87,19 @@ export const buildProposalStatusFilterOptions = ({ contracts = [], translate } =
   const options = [
     {
       key: 'realStatus:open',
-      label: translate?.('contract', 'status', 'open') || 'Em aberto',
+      label: translate?.('contract', 'status', 'open'),
       color: getProposalStatusColor('open'),
       normalizedStatus: 'open',
     },
     {
       key: 'realStatus:pending',
-      label: translate?.('contract', 'status', 'pending') || 'Pendente',
+      label: translate?.('contract', 'status', 'pending'),
       color: getProposalStatusColor('pending'),
       normalizedStatus: 'pending',
     },
     {
       key: 'realStatus:closed',
-      label: translate?.('contract', 'status', 'closed') || 'Fechado',
+      label: translate?.('contract', 'status', 'closed'),
       color: getProposalStatusColor('closed'),
       normalizedStatus: 'closed',
     },

--- a/src/tests/react/utils/proposalStatus.test.mjs
+++ b/src/tests/react/utils/proposalStatus.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildProposalStatusFilterOptions,
+  getProposalStatusColor,
+  getProposalStatusFilterKey,
+  getProposalStatusLabel,
+  normalizeProposalStatusKey,
+  proposalMatchesStatusFilter,
+} from '../../../react/utils/proposalStatus.js';
+
+const translate = (store, type, key) => `${store}.${type}.${key}`;
+
+test('normalizeProposalStatusKey normalizes separators and casing', () => {
+  assert.equal(normalizeProposalStatusKey(' Waiting_Signature '), 'waiting signature');
+});
+
+test('getProposalStatusLabel translates known backend statuses', () => {
+  assert.equal(
+    getProposalStatusLabel('awaiting signature', translate),
+    'contract.status.waitingSignature',
+  );
+  assert.equal(
+    getProposalStatusLabel('PENDENTE', translate),
+    'contract.status.pending',
+  );
+});
+
+test('getProposalStatusLabel falls back to the raw status when there is no mapping', () => {
+  assert.equal(getProposalStatusLabel('custom approval', translate), 'custom approval');
+});
+
+test('buildProposalStatusFilterOptions keeps fixed filters and appends API statuses', () => {
+  const options = buildProposalStatusFilterOptions({
+    contracts: [
+      {
+        status: {
+          id: 9,
+          status: 'Assinado',
+          realStatus: 'signed',
+          color: '#123456',
+        },
+      },
+    ],
+    translate,
+  });
+
+  assert.deepEqual(
+    options.slice(0, 3).map(item => item.key),
+    ['realStatus:open', 'realStatus:pending', 'realStatus:closed'],
+  );
+  assert.equal(options[3].key, '/statuses/9');
+  assert.equal(options[3].label, 'contract.status.signed');
+  assert.equal(options[3].color, '#123456');
+});
+
+test('proposalMatchesStatusFilter supports fixed and specific status filters', () => {
+  const contract = {
+    status: {
+      id: 9,
+      '@id': '/statuses/9',
+      status: 'Assinado',
+      realStatus: 'signed',
+    },
+  };
+  const options = buildProposalStatusFilterOptions({ contracts: [contract], translate });
+
+  assert.equal(proposalMatchesStatusFilter(contract, '/statuses/9', options), true);
+  assert.equal(proposalMatchesStatusFilter(contract, 'realStatus:signed', options), true);
+  assert.equal(proposalMatchesStatusFilter(contract, 'realStatus:open', options), false);
+});
+
+test('helpers expose consistent colors and filter keys', () => {
+  assert.equal(getProposalStatusColor('aberto'), '#3B82F6');
+  assert.equal(getProposalStatusFilterKey({ id: 5 }), '/statuses/5');
+});

--- a/src/tests/react/utils/proposalStatus.test.mjs
+++ b/src/tests/react/utils/proposalStatus.test.mjs
@@ -8,7 +8,7 @@ import {
   getProposalStatusLabel,
   normalizeProposalStatusKey,
   proposalMatchesStatusFilter,
-} from '../../../react/utils/proposalStatus.js';
+} from '@controleonline/ui-crm/src/react/utils/proposalStatus';
 
 const translate = (store, type, key) => `${store}.${type}.${key}`;
 
@@ -27,8 +27,8 @@ test('getProposalStatusLabel translates known backend statuses', () => {
   );
 });
 
-test('getProposalStatusLabel falls back to the raw status when there is no mapping', () => {
-  assert.equal(getProposalStatusLabel('custom approval', translate), 'custom approval');
+test('getProposalStatusLabel falls back to the canonical empty-state label', () => {
+  assert.equal(getProposalStatusLabel('custom approval', translate), 'contract.label.na');
 });
 
 test('buildProposalStatusFilterOptions keeps fixed filters and appends API statuses', () => {


### PR DESCRIPTION
## Issue
- Refs ControleOnline/app-community#61

## Summary
- extract the proposal status mapping and filter behavior into a dedicated helper
- cover translated labels, filter keys and status matching with a focused Node test suite
- publish a lightweight Pull Request Checks workflow so the validation is visible on the branch

## Validation
- npm run test:proposal-status
- commit status `local-validation/proposal-status = success`

## Notes
- this repository does not expose a `dev` branch, so `staging` is the closest review base available for this module.