### PR TITLE
feat: issue #55 add direct products shortcut for proposals

### DIFF
--- a/.github/workflows/pull-request-checks.yml
+++ b/.github/workflows/pull-request-checks.yml
@@ -27,3 +27,6 @@ jobs:
 
       - name: Run focused opportunity status tests
         run: node --test src/tests/react/utils/opportunityStatusFilter.test.cjs
+
+      - name: Run proposal products navigation tests
+        run: npm run test:proposal-products-navigation

--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "license": "MIT",
   "main": "src/vue/index.js",
   "scripts": {
-    "test": "npm run test:crm-empty-state && npm run test:opportunity-status-filter",
+    "test": "npm run test:crm-empty-state && npm run test:opportunity-status-filter && npm run test:proposal-products-navigation",
     "test:crm-empty-state": "node --test src/tests/react/utils/opportunityEmptyState.test.js",
     "test:opportunity-status-filter": "node --test src/tests/react/utils/opportunityStatusFilter.test.cjs",
+    "test:proposal-products-navigation": "node --test src/tests/react/pages/proposals/navigation.test.js",
     "test:coverage": "c8 --reporter=clover --report-dir coverage npm test"
   },
   "devDependencies": {
@@ -16,9 +17,7 @@
   },
   "repository": {
     "type": "git",
-
     "url": "https://github.com/controleonline/conline-quasar-ui"
-
   },
   "bugs": "",
   "homepage": "https://www.controleonline.com/devs/plugins",

--- a/src/react/pages/proposals/ProposalDetails.js
+++ b/src/react/pages/proposals/ProposalDetails.js
@@ -70,7 +70,7 @@ const PropostaTab = ({ contract, fileContent, fileLoading, fileError, canEdit, h
 const ProposalDetails = () => {
   const navigation = useNavigation();
   const route = useRoute();
-  const { contractId } = route.params;
+  const { contractId, initialTab } = route.params;
 
   const { showSuccess, showError } = useMessage();
 
@@ -95,6 +95,15 @@ const ProposalDetails = () => {
       title: global.t?.t('contract', 'title', 'proposal') || 'Proposta',
     });
   }, [navigation]);
+
+  useEffect(() => {
+    if (String(initialTab || '').trim().toLowerCase() === 'products') {
+      setActiveTab(1);
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ x: width, animated: false });
+      });
+    }
+  }, [initialTab]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -141,7 +150,7 @@ const ProposalDetails = () => {
     }
   };
 
-  const handleTabPress = (index) => {
+  const handleTabPress = index => {
     setActiveTab(index);
     scrollRef.current?.scrollTo({ x: index * width, animated: true });
   };

--- a/src/react/pages/proposals/index.js
+++ b/src/react/pages/proposals/index.js
@@ -488,11 +488,7 @@ const ProposalsPage = () => {
     : allContracts;
 
   const renderProposal = ({ item: contract }) => (
-    <TouchableOpacity
-      style={styles.card}
-      onPress={() => navigation.navigate('ProposalDetails', { contractId: contract.id })}
-      activeOpacity={0.9}
-    >
+    <View style={styles.card}>
       <View style={styles.cardHeader}>
         <View style={styles.headerContent}>
           <Text style={styles.cardTitle}>
@@ -543,10 +539,32 @@ const ProposalsPage = () => {
       </View>
 
       <View style={styles.cardFooter}>
-        <Text style={styles.viewDetailsText}>{global.t?.t('contract','action', 'viewDetails')}</Text>
-        <Icon name="chevron-right" size={12} color={colors.primary} />
+        <View style={styles.footerActions}>
+          <TouchableOpacity
+            style={styles.footerButton}
+            onPress={() =>
+              navigation.navigate('ProposalDetails', {
+                contractId: contract.id,
+                initialTab: 'products',
+              })
+            }
+            activeOpacity={0.85}>
+            <MaterialIcon name="inventory-2" size={16} color="#64748B" />
+            <Text style={styles.footerButtonText}>Produtos</Text>
+          </TouchableOpacity>
+
+          <TouchableOpacity
+            style={[styles.footerButton, styles.footerButtonPrimary]}
+            onPress={() => navigation.navigate('ProposalDetails', { contractId: contract.id })}
+            activeOpacity={0.85}>
+            <Text style={[styles.viewDetailsText, styles.footerButtonTextPrimary]}>
+              {global.t?.t('contract','action', 'viewDetails')}
+            </Text>
+            <Icon name="chevron-right" size={12} color={colors.primary} />
+          </TouchableOpacity>
+        </View>
       </View>
-    </TouchableOpacity>
+    </View>
   );
 
   return (

--- a/src/react/pages/proposals/index.styles.js
+++ b/src/react/pages/proposals/index.styles.js
@@ -176,13 +176,42 @@ const styles = StyleSheet.create({
   cardFooter: {
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'flex-end',
+    justifyContent: 'space-between',
+    gap: 8,
+  },
+  footerActions: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+  },
+  footerButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: '#F8FAFC',
+  },
+  footerButtonPrimary: {
+    borderColor: colors.primary,
+    backgroundColor: '#E7F3FF',
+  },
+  footerButtonText: {
+    fontSize: 13,
+    fontWeight: '600',
+    color: colors.textSecondary,
+    marginLeft: 6,
+  },
+  footerButtonTextPrimary: {
+    color: colors.primary,
   },
   viewDetailsText: {
     fontSize: 13,
     fontWeight: '600',
     color: colors.primary,
-    marginRight: 4,
   },
   loadingContainer: {
     padding: 32,
@@ -216,4 +245,3 @@ export default styles;
 export const inlineStyle_669_129 = {
   marginVertical: 20,
 };
-

--- a/src/tests/react/pages/proposals/navigation.test.js
+++ b/src/tests/react/pages/proposals/navigation.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const proposalsPageSource = fs.readFileSync(
+  path.resolve(__dirname, '../../../..', 'react/pages/proposals/index.js'),
+  'utf8',
+);
+
+const proposalDetailsSource = fs.readFileSync(
+  path.resolve(__dirname, '../../../..', 'react/pages/proposals/ProposalDetails.js'),
+  'utf8',
+);
+
+test('proposal list products shortcut opens ProposalDetails with the products tab selected', () => {
+  assert.match(
+    proposalsPageSource.replace(/\s+/g, ' '),
+    /navigation\.navigate\('ProposalDetails', (buildProposalProductsParams\(contract\.id\)|\{[^}]*contractId:\s*contract\.id,[^}]*initialTab:\s*'products'[^}]*\})\)/,
+  );
+});
+
+test('proposal details normalize the products tab request before selecting the products tab', () => {
+  assert.match(
+    proposalDetailsSource.replace(/\s+/g, ' '),
+    /(String\(initialTab \|\| ''\)\.trim\(\)\.toLowerCase\(\) === 'products'|getProposalInitialTabIndex\(initialTab\))/,
+  );
+});
+
+test('proposal details switch the active tab to Produtos when the route asks for it', () => {
+  assert.match(
+    proposalDetailsSource.replace(/\s+/g, ' '),
+    /(setActiveTab\(1\)|setActiveTab\(targetTabIndex\))/,
+  );
+  assert.match(
+    proposalDetailsSource.replace(/\s+/g, ' '),
+    /scrollRef\.current\?\.scrollTo\(\{\s*x:\s*(width|targetTabIndex \* width),\s*animated:\s*false\s*\}\)/,
+  );
+});


### PR DESCRIPTION
## Resumo
- adiciona um atalho direto para abrir a proposta na aba de produtos
- mantém a tela de detalhes reconhecendo `initialTab: 'products'`
- adiciona cobertura automatizada focada para esse contrato de navegação

## Relação
- relates to ControleOnline/app-community#55

## Validação
- `npm run test:proposal-products-navigation`
- `npm test`
- workflow `Pull Request Checks` no próprio módulo

## Observação
- branch `task-55` reconstruída a partir do `master` atual para remover deltas antigos fora do escopo