### PR TITLE
draft: prepare opportunity editor reference normalization for issue #13

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,9 +6,10 @@
   "license": "MIT",
   "main": "src/vue/index.js",
   "scripts": {
-    "test": "npm run test:crm-empty-state && npm run test:opportunity-status-filter",
+    "test": "npm run test:crm-empty-state && npm run test:opportunity-status-filter && npm run test:opportunity-editor-references",
     "test:crm-empty-state": "node --test src/tests/react/utils/opportunityEmptyState.test.js",
     "test:opportunity-status-filter": "node --test src/tests/react/utils/opportunityStatusFilter.test.cjs",
+    "test:opportunity-editor-references": "node --test src/tests/react/utils/opportunityEditorReferences.test.js",
     "test:coverage": "c8 --reporter=clover --report-dir coverage npm test"
   },
   "devDependencies": {

--- a/src/react/utils/opportunityEditorReferences.js
+++ b/src/react/utils/opportunityEditorReferences.js
@@ -11,16 +11,29 @@ const getOpportunityEditorReferenceValue = value => {
   return String(rawValue || '').trim();
 };
 
-const resolveOpportunityEditorOption = (value, options = []) => {
+const getComparableOpportunityEditorReferenceValue = value => {
   const identity = getOpportunityEditorReferenceValue(value);
+
+  if (!identity) {
+    return '';
+  }
+
+  const match = identity.match(/\/(\d+)$/);
+  return match ? match[1] : identity;
+};
+
+const resolveOpportunityEditorOption = (value, options = []) => {
+  const identity = getComparableOpportunityEditorReferenceValue(value);
 
   if (!identity) {
     return value || null;
   }
 
   return (
-    options.find(option => getOpportunityEditorReferenceValue(option) === identity) ||
-    value
+    options.find(
+      option =>
+        getComparableOpportunityEditorReferenceValue(option) === identity,
+    ) || value
   );
 };
 

--- a/src/react/utils/opportunityEditorReferences.js
+++ b/src/react/utils/opportunityEditorReferences.js
@@ -37,7 +37,40 @@ const resolveOpportunityEditorOption = (value, options = []) => {
   );
 };
 
+const normalizeOpportunityEditorDraft = ({
+  opportunity,
+  statusOptions = [],
+  categoryOptions = [],
+  criticalityOptions = [],
+  reasonOptions = [],
+}) => {
+  if (!opportunity || typeof opportunity !== 'object') {
+    return opportunity || null;
+  }
+
+  return {
+    ...opportunity,
+    taskStatus: resolveOpportunityEditorOption(
+      opportunity.taskStatus,
+      statusOptions,
+    ),
+    category: resolveOpportunityEditorOption(
+      opportunity.category,
+      categoryOptions,
+    ),
+    criticality: resolveOpportunityEditorOption(
+      opportunity.criticality,
+      criticalityOptions,
+    ),
+    reason: resolveOpportunityEditorOption(
+      opportunity.reason,
+      reasonOptions,
+    ),
+  };
+};
+
 module.exports = {
   getOpportunityEditorReferenceValue,
+  normalizeOpportunityEditorDraft,
   resolveOpportunityEditorOption,
 };

--- a/src/react/utils/opportunityEditorReferences.js
+++ b/src/react/utils/opportunityEditorReferences.js
@@ -1,0 +1,30 @@
+const getOpportunityEditorReferenceValue = value => {
+  if (!value) {
+    return '';
+  }
+
+  const rawValue =
+    typeof value === 'object'
+      ? value['@id'] ?? value.id ?? value.value
+      : value;
+
+  return String(rawValue || '').trim();
+};
+
+const resolveOpportunityEditorOption = (value, options = []) => {
+  const identity = getOpportunityEditorReferenceValue(value);
+
+  if (!identity) {
+    return value || null;
+  }
+
+  return (
+    options.find(option => getOpportunityEditorReferenceValue(option) === identity) ||
+    value
+  );
+};
+
+module.exports = {
+  getOpportunityEditorReferenceValue,
+  resolveOpportunityEditorOption,
+};

--- a/src/tests/react/utils/opportunityEditorReferences.test.js
+++ b/src/tests/react/utils/opportunityEditorReferences.test.js
@@ -1,0 +1,39 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const {
+  getOpportunityEditorReferenceValue,
+  resolveOpportunityEditorOption,
+} = require('../../../react/utils/opportunityEditorReferences');
+
+test('getOpportunityEditorReferenceValue reads object references and raw values', () => {
+  assert.equal(
+    getOpportunityEditorReferenceValue({ '@id': '/categories/4', id: 9 }),
+    '/categories/4',
+  );
+  assert.equal(getOpportunityEditorReferenceValue({ id: 7 }), '7');
+  assert.equal(getOpportunityEditorReferenceValue('/statuses/2'), '/statuses/2');
+});
+
+test('resolveOpportunityEditorOption returns the loaded option that matches the reference', () => {
+  const options = [
+    { '@id': '/categories/4', name: 'Inbound' },
+    { '@id': '/categories/8', name: 'Referral' },
+  ];
+
+  assert.deepEqual(
+    resolveOpportunityEditorOption('/categories/8', options),
+    options[1],
+  );
+  assert.deepEqual(
+    resolveOpportunityEditorOption({ id: 4 }, options),
+    options[0],
+  );
+});
+
+test('resolveOpportunityEditorOption preserves the original value when no expanded option is available', () => {
+  assert.equal(
+    resolveOpportunityEditorOption('/categories/99', [{ '@id': '/categories/4' }]),
+    '/categories/99',
+  );
+});

--- a/src/tests/react/utils/opportunityEditorReferences.test.js
+++ b/src/tests/react/utils/opportunityEditorReferences.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 
 const {
   getOpportunityEditorReferenceValue,
+  normalizeOpportunityEditorDraft,
   resolveOpportunityEditorOption,
 } = require('../../../react/utils/opportunityEditorReferences');
 
@@ -35,5 +36,35 @@ test('resolveOpportunityEditorOption preserves the original value when no expand
   assert.equal(
     resolveOpportunityEditorOption('/categories/99', [{ '@id': '/categories/4' }]),
     '/categories/99',
+  );
+});
+
+test('normalizeOpportunityEditorDraft resolves all relationship references against loaded options', () => {
+  const statusOptions = [{ '@id': '/statuses/3', status: 'Open' }];
+  const categoryOptions = [{ '@id': '/categories/8', name: 'Referral' }];
+  const criticalityOptions = [{ '@id': '/categories/5', name: 'Hot' }];
+  const reasonOptions = [{ '@id': '/categories/11', name: 'WhatsApp' }];
+
+  assert.deepEqual(
+    normalizeOpportunityEditorDraft({
+      opportunity: {
+        id: 13,
+        taskStatus: 3,
+        category: '/categories/8',
+        criticality: { id: 5 },
+        reason: '/categories/11',
+      },
+      statusOptions,
+      categoryOptions,
+      criticalityOptions,
+      reasonOptions,
+    }),
+    {
+      id: 13,
+      taskStatus: statusOptions[0],
+      category: categoryOptions[0],
+      criticality: criticalityOptions[0],
+      reason: reasonOptions[0],
+    },
   );
 });


### PR DESCRIPTION
## Issue
- Refs ControleOnline/ui-crm#13

## Summary
- publish the helper foundation already validated on `task-13` for opportunity editor reference handling
- keep the branch reviewable while the main integration in `src/react/pages/crm/index.js` is still pending
- preserve the task in `Developer` because the fix is not complete yet

## What is already in this branch
- `src/react/utils/opportunityEditorReferences.js`
- `src/tests/react/utils/opportunityEditorReferences.test.js`
- `package.json` test script wiring for `npm run test:opportunity-editor-references`

## Validation already confirmed on this branch
- `task-13` is `ahead_by=4` and `behind_by=0` against `master`
- the focused helper test passes: `npm run test:opportunity-editor-references`
- there is still no open PR for `head:task-13`

## Remaining work before review readiness
- integrate the helper into `src/react/pages/crm/index.js`
- normalize `taskStatus`, `category`, `criticality` and `reason` in `handleEditOpportunity`
- use `getOpportunityEditorReferenceValue(...)` in `handleSaveEdit`
- use the same reference serialization fallback in `handleSaveNewOpportunity`

## Status
Draft on purpose: this branch is a tracked work surface, not a finished delivery yet.